### PR TITLE
initial CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+# Java Gradle CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.gradle" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: gradle dependencies
+
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: v1-dependencies-{{ checksum "build.gradle" }}
+
+      # run tests!
+      - run: gradle test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,3 +39,14 @@ jobs:
 
       # run tests!
       - run: gradle test
+
+      - store_test_results:
+          path: ./build/test-results
+
+      - store_artifacts:
+          path: ./build/reports
+          destination: ikaqa-reports
+
+      - store_artifacts:
+          path: ./build/test-results
+          destination: ikaqa-test-results

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
@@ -18,7 +18,7 @@ class IkaQAControllerTest {
 
     @Test
     public void executeSlashCommand() {
-        assertEquals("call postMessageX", ikaQAController.executeSlashCommand());
+        assertEquals("call postMessage", ikaQAController.executeSlashCommand());
     }
 
 

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
@@ -18,7 +18,7 @@ class IkaQAControllerTest {
 
     @Test
     public void executeSlashCommand() {
-        assertEquals("call postMessage", ikaQAController.executeSlashCommand());
+        assertEquals("call postMessageX", ikaQAController.executeSlashCommand());
     }
 
 

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/ikaQAApplicationTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/ikaQAApplicationTest.java
@@ -1,0 +1,20 @@
+package jp.co.heartsoft.ikaqa.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class ikaQAApplicationTest {
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    void tearDown() {
+    }
+
+    @org.junit.jupiter.api.Test
+    void main() {
+        org.junit.jupiter.api.Assertions.assertEquals(0, 1);
+    }
+}

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/ikaQAApplicationTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/ikaQAApplicationTest.java
@@ -15,6 +15,6 @@ class ikaQAApplicationTest {
 
     @org.junit.jupiter.api.Test
     void main() {
-        org.junit.jupiter.api.Assertions.assertEquals(0, 1);
+        org.junit.jupiter.api.Assertions.assertEquals(0, 0);
     }
 }


### PR DESCRIPTION
CircleCIの設定ファイルを初期作成するプルリクです。
https://github.com/ikaQA/ikaQA_proto
と同等のもの＋下記の対応をしています。
- テストを実行する
- テスト結果を表示する
- テスト結果を保存する

また、テスト結果の確認ができるよう、テストクラスを追加してそのテストはNGとなるようにしています。

保存したテスト結果は、CircleCIの編集権限がないと表示されないようですが、
下記のようにテスト結果のURLに `#artifacts` を付与すれば参照可能です。
https://circleci.com/gh/ikaQA/ikaQA/6#artifacts

皆さんの確認が終了したら、テストOKになるように戻してマージしようと思います。