### PR TITLE
POSTリクエストを受信できるようにする

### DIFF
--- a/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
+++ b/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
@@ -1,6 +1,8 @@
 package jp.co.heartsoft.ikaqa.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -9,5 +11,11 @@ public class IkaQAController {
     public String executeSlashCommand() {
         System.out.println("execute SlashCommand");
         return "call postMessage";
+    }
+
+    @PostMapping("/ikaqaDebug")
+    public String ikaqaDebug(@RequestBody String requestBody) {
+        System.out.println("requestBody = " + requestBody);
+        return "ikaqaDebug(" + requestBody + ")";
     }
 }

--- a/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
+++ b/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
@@ -1,9 +1,6 @@
 package jp.co.heartsoft.ikaqa.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class IkaQAController {
@@ -14,7 +11,7 @@ public class IkaQAController {
     }
 
     @PostMapping("/ikaqaDebug")
-    public String ikaqaDebug(@RequestBody String requestBody) {
+    public @ResponseBody String ikaqaDebug(@RequestBody String requestBody) {
         System.out.println("requestBody = " + requestBody);
         return "ikaqaDebug(" + requestBody + ")";
     }

--- a/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
+++ b/src/main/java/jp/co/heartsoft/ikaqa/controller/IkaQAController.java
@@ -1,6 +1,10 @@
 package jp.co.heartsoft.ikaqa.controller;
 
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class IkaQAController {
@@ -13,6 +17,9 @@ public class IkaQAController {
     @PostMapping("/ikaqaDebug")
     public @ResponseBody String ikaqaDebug(@RequestBody String requestBody) {
         System.out.println("requestBody = " + requestBody);
-        return "ikaqaDebug(" + requestBody + ")";
+
+        String responseBody = "ikaqaDebug(" + requestBody + ")";
+        System.out.println("responseBody = " + responseBody);
+        return responseBody;
     }
 }

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
@@ -21,5 +21,8 @@ class IkaQAControllerTest {
         assertEquals("call postMessage", ikaQAController.executeSlashCommand());
     }
 
-
+    @Test
+    void textIkaqaDebug() {
+        assertEquals("ikaqaDebug(test)", ikaQAController.ikaqaDebug("test"));
+    }
 }

--- a/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
+++ b/src/test/java/jp/co/heartsoft/ikaqa/controller/IkaQAControllerTest.java
@@ -22,7 +22,7 @@ class IkaQAControllerTest {
     }
 
     @Test
-    void textIkaqaDebug() {
+    void testIkaqaDebug() {
         assertEquals("ikaqaDebug(test)", ikaQAController.ikaqaDebug("test"));
     }
 }


### PR DESCRIPTION
SlackのスラッシュコマンドからのリクエストはPOSTになるため、POSTリクエストを受信できるように設定します。

このブランチをデプロイし、 `@PostMapping("/ikaqaDebug")` で指定してるURLへPOSTリクエストすると、リクエスト内容が応答されるようになります。